### PR TITLE
Fix booking, WhatsApp, and dashboard appointments

### DIFF
--- a/project/src/context/BarberContext.tsx
+++ b/project/src/context/BarberContext.tsx
@@ -1,5 +1,5 @@
 // src/context/BarberContext.tsx
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useEffect, useState } from "react";
 import { Barber, Booking } from "../types";
 
 interface BarberContextProps {
@@ -48,7 +48,8 @@ export const BarberProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       phone: "+1 234 567 8903"
     }
   ]);
-  const [bookings, setBookings] = useState<Booking[]>([
+  // Estado inicial de reservas con soporte de persistencia en localStorage
+  const defaultBookings: Booking[] = [
     {
       id: "1",
       barberId: "1",
@@ -79,7 +80,23 @@ export const BarberProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       customerPhone: "+1 234 567 8902", 
       customerEmail: "carlos@email.com"
     }
-  ]);
+  ];
+
+  const [bookings, setBookings] = useState<Booking[]>(() => {
+    try {
+      const saved = localStorage.getItem("bookings");
+      return saved ? JSON.parse(saved) as Booking[] : defaultBookings;
+    } catch {
+      return defaultBookings;
+    }
+  });
+
+  // Persistir reservas en localStorage cuando cambien
+  useEffect(() => {
+    try {
+      localStorage.setItem("bookings", JSON.stringify(bookings));
+    } catch {}
+  }, [bookings]);
 
   const addBarber = (barber: Barber) => {
     setBarbers((prev) => [...prev, barber]);


### PR DESCRIPTION
Implement booking persistence using `localStorage` to ensure new appointments are visible in the dashboard after page reloads.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e2ed499-878d-4e4d-8b4d-aac8960b6b83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e2ed499-878d-4e4d-8b4d-aac8960b6b83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

